### PR TITLE
Formatting tweaks to products.graphql

### DIFF
--- a/products.graphql
+++ b/products.graphql
@@ -1,5 +1,5 @@
-# This schema uses Apollo Connectors, a declarative programming model for 
-# GraphQL that allows you to plug in your existing REST services directly into 
+# This schema uses Apollo Connectors, a declarative programming model for
+# GraphQL that allows you to plug in your existing REST services directly into
 # a graph. To learn more, visit Apollo's documentation: 🔗https://www.apollographql.com/docs/graphos/schema-design/connectors
 
 # Guided tutorial: 🔗 https://www.apollographql.com/docs/graphos/get-started/guides/rest
@@ -11,21 +11,21 @@ extend schema
   @link( # Enable this schema to use Apollo Connectors
     url: "https://specs.apollo.dev/connect/v0.1"
     import: ["@connect", "@source"]
-  ) 
+  )
 
 # A @source directive defines a shared data source for multiple Connectors.
 # ✏️ Replace the `name` and `baseURL` of this @source with your own REST API.
-  @source(
-    name: "ecomm"
-# A @source directive defines a shared data source for multiple Connectors.
-    http: { 
-      baseURL: "https://ecommerce.demo-api.apollo.dev/" 
-      headers: [ 
-        # If your API requires headers, add them here and in your router.yaml file.
-        { name: "name", value: "{$config.apiKey}" }
-      ]
-    }
-  )
+@source(
+  name: "ecomm"
+  # A @source directive defines a shared data source for multiple Connectors.
+  http: {
+    baseURL: "https://ecommerce.demo-api.apollo.dev/"
+    headers: [
+      # If your API requires headers, add them here and in your router.yaml file.
+      { name: "name", value: "{$config.apiKey}" }
+    ]
+  }
+)
 
 # ✏️ Replace this example type with your own object type.
 type Product {
@@ -44,9 +44,9 @@ type Query {
     @connect(
       source: "ecomm"
       http: { GET: "/products" } # GET, POST, PUT, PATCH, DELETE.
-	  # Use @connect for any field that should be resolved by your REST API endpoints.
-        # Use the selection argument to map fields from the JSON response to the type.
-        # You can do more with this selection mapping. Lean more at 🔗 https://www.apollographql.com/docs/graphos/schema-design/connectors/responses
+      # Use @connect for any field that should be resolved by your REST API endpoints.
+      # Use the selection argument to map fields from the JSON response to the type.
+      # You can do more with this selection mapping. Lean more at 🔗 https://www.apollographql.com/docs/graphos/schema-design/connectors/responses
       selection: """
       $.products {
         id


### PR DESCRIPTION
I got a few indentation/blankspace warnings from my editor in the `rover init` flow.  Not a big deal at all, but in the interest of removing any potential user distraction I cleaned them up.  Thanks!