### PR TITLE
feat(start-with-typescript): Update `getting-started.md` with clearer server startup instructions 

### DIFF
--- a/start-with-typescript/getting-started.md
+++ b/start-with-typescript/getting-started.md
@@ -43,9 +43,10 @@ The server is in charge of making sure requests are valid, finding the right dat
 
 ## Make your first request
 
-1. Open `products.graphql` and take a look at your starter schema.
-2. In the terminal, run the `rover dev` command provided in the output of `rover init` under **Next steps**. The `dev` command starts a local development session and gives you access to Apollo Sandbox—a local, in-browser GraphQL playground, where you can run GraphQL operations and test your API as you design it.
-3. In Sandbox, paste the following GraphQL query in the **Operation** section:
+1. Start the server by running `npm ci && npm start` in the terminal.
+2. Open `products.graphql` and take a look at your starter schema.
+3. In a new terminal window, run the `rover dev` command provided in the output of `rover init` under **Next steps**. The `dev` command starts a local development session and gives you access to Apollo Sandbox—a local, in-browser GraphQL playground, where you can run GraphQL operations and test your API as you design it.
+4. In Sandbox, paste the following GraphQL query in the **Operation** section:
 
 ```
 query GetProducts {
@@ -57,7 +58,7 @@ query GetProducts {
 }
 ```
 
-4. Click  `► GetProducts` to run the request. You'll get a response back with data for the product's id, name, and description; exactly the properties you asked for in the query! 🎉
+5. Click  `► GetProducts` to run the request. You'll get a response back with data for the product's id, name, and description; exactly the properties you asked for in the query! 🎉
 
 # Time to build your API
 


### PR DESCRIPTION
### Changes:
- Added explicit step for the TypeScript template to start the server using `npm ci && npm start`
- Updated step numbering to accommodate the new server startup step
- Clarified that `rover dev` should be run in a new terminal window

This change improves the onboarding experience by making the server startup process more explicit and ensuring users have the server running before attempting to use `rover dev`.