### PR TITLE
Add Community link to `getting-started.md` (for both Connectors & TypeScript)

### DIFF
--- a/start-with-rest/getting-started.md
+++ b/start-with-rest/getting-started.md
@@ -58,7 +58,7 @@ Then, follow the development cycle below:
 
 To learn more about headers and other advanced features like configuring environment variables, telemetry, and authentication, visit [Apollo’s docs on working with Router](https://community.apollographql.com/c/graph-os/getting-started/35).
 
-ℹ️ If you run into any issues or difficulties, please reach out via the [Apollo Community here](https://community.apollographql.com/c/graph-os/getting-started/35) and click “New Topic”–the Apollo team is here to help!
+ℹ️ If you run into any issues or difficulties, please reach out via the [Apollo Community](https://community.apollographql.com/c/graph-os/getting-started/35). Click **New Topic** to start a discussion–the Apollo team is here to help!
 
 # Debugging your schema
 

--- a/start-with-typescript/getting-started.md
+++ b/start-with-typescript/getting-started.md
@@ -74,7 +74,7 @@ Then, follow the development cycle below:
 
 Whenever you modify your schema, run `npm run codegen` to ensure your generated types are up to date as well.
 
-ℹ️ If you run into any issues or difficulties, please reach out via the [Apollo Community here](https://community.apollographql.com/c/graph-os/getting-started/35) and click “New Topic”–the Apollo team is here to help!
+ℹ️ If you run into any issues or difficulties, please reach out via the [Apollo Community](https://community.apollographql.com/c/graph-os/getting-started/35). Click **New Topic** to start a discussion–the Apollo team is here to help!
 
 # Debugging your schema
 

--- a/start-with-typescript/getting-started.md
+++ b/start-with-typescript/getting-started.md
@@ -74,6 +74,8 @@ Then, follow the development cycle below:
 
 Whenever you modify your schema, run `npm run codegen` to ensure your generated types are up to date as well.
 
+ℹ️ If you run into any issues or difficulties, please reach out via the [Apollo Community here](https://community.apollographql.com/c/graph-os/getting-started/35) and click “New Topic”–the Apollo team is here to help!
+
 # Debugging your schema
 
 The Apollo dev toolkit includes a few debugging tools to help you design and develop your graph. The journey looks a little something like this:


### PR DESCRIPTION
Adding a link to the Apollo Community under `Time to build your API` (for consistency—this matches what we do in the `getting-started.md` file for 📁 `start-with-rest`).