### PR TITLE
Remove start-with-rest/supergraph.yaml

### DIFF
--- a/start-with-rest/supergraph.yaml
+++ b/start-with-rest/supergraph.yaml
@@ -1,9 +1,0 @@
-# A "supergraph" is a unified GraphQL API composed of different services known as "subgraphs"
-
-# Set the maximum Apollo Federation version that subgraphs in this supergraph can use. Lean more at 🔗 https://www.apollographql.com/docs/graphos/schema-design/connectors/directives#prerequisites
-federation_version: =2.11.0
-subgraphs: # Use this section to add all of the services that make up your supergraph
-  products: # Your first subgraph has been named `products`
-    routing_url: http://placeholder # This value is unused but cannot be empty
-    schema:
-      file: products.graphql # The path to your schema (.graphql) file


### PR DESCRIPTION
This PR removes the `start-with-rest/supergraph.yaml` file, which is erroneous. The `supergraph.yaml` file is generated by the `rover init` command: https://github.com/apollographql/rover/blob/main/src/command/init/template_operations.rs#L201

### Testing steps
1. Removed `start-with-rest/supergraph.yaml` file
2. Pushed changes to `origin/schema-rename`
3. Updated `rover` to pull templates from `schema-rename` branch by modifying `[repo_ref](https://github.com/apollographql/rover/blob/dd29b918fc84f862ab68c300b39d7f336d93f8ea/src/command/init/transitions.rs#L242)` locally
4. Ran `cargo build` to build `rover` changes
5. Aliased `cargo rover` to `localrover` with `alias localrover='cargo run --manifest-path=/Users/alyssahursh/code/rover/Cargo.toml --bin rover --'`
6. Created new empty test directory
7. Ran `localrover init`
8. Verified `supergraph.yaml` file was created as expected:

```
subgraphs:
  products:
    routing_url: http://ignore
    schema:
      file: products.graphql
federation_version: =2.11.0
```

This PR is part of a 2025 Hackathon project to simplify the `rover init` experience.