### PR TITLE
Rename products.graphql to schema.graphql

### DIFF
--- a/start-with-rest/getting-started.md
+++ b/start-with-rest/getting-started.md
@@ -78,7 +78,7 @@ Once you’ve made changes to your schema files and are happy with the state of 
 ```
 rover subgraph publish your-graph-id@main \ # Replace this with your `APOLLO_GRAPH_REF` value
   --schema "./schema.graphql" \
-  --name {name_of_your_subgraph} \
+  --name your-subgraph-name-subgraph \ # Replace this with {your-subgraph-name}-subgraph 
   --routing-url "https://my-running-subgraph.com/api" # If you don't have a running API yet, you can replace this with http://localhost:4000
 ```
 


### PR DESCRIPTION
This PR renames the starter `products.graphql` file to a more generic `schema.graphql` file. Initializing a new project should be as unopinionated as possible. Not all customers have the concept of "products," and trying to change the name of the subgraph causes unnecessary friction. 

This PR is intended to be deployed with compensating changes in `rover`: https://github.com/apollographql/rover/pull/2647. Without those compensating changes, running `rover init` and selecting a Connectors project will panic when it encounters a root-level `.graphql` file named `schema`. Merge with caution!

This PR is part of the 2025 Hackathon.
