### PR TITLE
Documentation updates in preparation for `deploy` updates in Studio

### DIFF
--- a/start-with-rest/getting-started.md
+++ b/start-with-rest/getting-started.md
@@ -40,7 +40,7 @@ Once you run the command, the CLI will start watching your files for updates. Ev
 
 ## The design process
 
-The best way to get started with schema design is to check out the different [schema types](https://www.apollographql.com/docs/graphos/schema-design) that make up your graph. You can also skip and go straight to Apollo’s Schema Design Guides and Principles, starting with [Demand-Oriented Schema Design](https://www.apollographql.com/docs/graphos/schema-design/guides/demand-oriented-schema-design).
+The best way to get started with schema design is to check out the different [schema types](https://www.apollographql.com/docs/graphos/schema-design) that make up your graph. You can also go straight to Apollo’s schema design guides, starting with [Demand-Oriented Schema Design](https://www.apollographql.com/docs/graphos/schema-design/guides/demand-oriented-schema-design).
 
 ## Debugging Apollo Connectors
 

--- a/start-with-rest/getting-started.md
+++ b/start-with-rest/getting-started.md
@@ -1,102 +1,76 @@
-👋 Hi there! This guide walks you through integrating REST APIs into your graph using [Apollo Connectors](https://www.apollographql.com/docs/graphos/schema-design/connectors).
 
-- [Setup](#setup)
-  - [Part two: Check out how Connectors work](#part-two-check-out-how-connectors-work)
-- [Time to build your API](#time-to-build-your-api)
-- [Debugging your schema](#debugging-your-schema)
-  - [Design your schema with Apollo’s IDE extensions](#design-your-schema-with-apollos-ide-extensions)
-  - [Check for errors each time you save](#check-for-errors-each-time-you-save)
-  - [Debug Connectors in Sandbox](#debug-connectors-in-sandbox)
+- [Overview](#overview)
+- [Designing your graph](#designing-your-graph)
+  - [IDE extensions for graph development](#ide-extensions-for-graph-development)
+  - [Working on your graph locally](#working-on-your-graph-locally)
+  - [The design process](#the-design-process)
+  - [Debugging Apollo Connectors](#debugging-apollo-connectors)
 - [Publishing changes to GraphOS Studio](#publishing-changes-to-graphos-studio)
+- [Deploying Apollo Router](#deploying-apollo-router)
 - [Security](#security)
 - [Additional resources](#additional-resources)
-  - [Deploying your graph](#deploying-your-graph)
-  - [More on graph development](#more-on-graph-development)
-  - [More about Connectors](#more-about-connectors)
+  - [Graph development](#graph-development)
+  - [Connectors](#connectors)
+  - [Apollo Router](#apollo-router)
 
-# Setup
 
-1. Open `products.graphql` to take a look at your graph's starter schema. Ignore the comments labeled with a ✏️ for now, we’ll get to them later.
-2. In the terminal, run the `rover dev` command provided in the output of `rover init` under **Next steps**. The `dev` command starts a local development session and gives you access to Apollo Sandbox—a local, in-browser GraphQL playground, where you can run GraphQL operations and test your API as you design it.
-3. In Sandbox, paste the following GraphQL query in the **Operation** section:
+# Overview
 
-```
-query GetProducts {
-  products {
-    id
-    name
-    description
-  }
-}
-```
+👋 Hi there!
 
-4. Click `► GetProducts` to run the request. You'll get a response back with data for the product's id, name, and description; exactly the properties you asked for in the query! 🎉
+Your new graph is set up with [Apollo Federation](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/federation). This means it’s built to grow, even if you’re starting with just one service. Right now, that service is defined in `products.graphql`, and you can treat it like a regular GraphQL API as you build it out.
 
-## Part two: Check out how Connectors work
+This project is also set up to use [Apollo Router](https://www.apollographql.com/docs/graphos/routing) as the entry point for all requests to your graph. It’s a great way to get features like tracing, metrics, and caching out of the box. It gives you a single place to configure settings for your graph, like traffic shaping, authorization, and more. For now, the router simply forwards requests to your service, but as your graph grows, it can pull data from multiple places and return one clear, consistent result.
 
-1. Let's find out where this data is coming from. Click the arrow next to **Response** and select the **Connectors Debugger** option.
-2. Now, click the most recent request to review its details. In the **Request overview** tab, press the **cURL** button to copy the underlying HTTP request made to the REST API. 
-3. Run this request in your terminal and compare it with what’s been configured using the `@connect` directive in `products.graphql`. You'll notice that some properties in the terminal response match to the `selection` mapping in the schema. This is the key to how Connectors work!
+Finally, this graph also uses [Apollo Connectors](https://www.apollographql.com/docs/graphos/connectors), which let you integrate REST APIs directly into your GraphQL schema without writing any resolver code or deploying a backend GraphQL server. Instead of building separate services to connect your APIs, you simply add declarative directives such as `@connect` and `@source` to your schema, and Apollo Router automatically handles the REST API calls and data transformation for you.
 
-Hooray! You ran a query, got some data back, and reviewed what Connectors are like under the hood! Feel free to experiment some more–try tweaking the query to see what data you can retrieve. 🚀
+# Designing your graph
 
-# Time to build your API
+## IDE extensions for graph development
 
-You’re all set to start building. You'll be working primarily with the `products.graphql` file.
+[Apollo’s IDE extensions](https://www.apollographql.com/docs/ide-support) are designed to help you catch and correct any issues related to schema design as early as possible. Lean on their instant feedback and autocomplete capabilities to help you create the types, fields, arguments, and connectors.
 
-First, make sure you’ve installed and configured [your IDE extension of choice](https://www.apollographql.com/docs/graphos/schema-design/ide-support) so you can rely on its autocompletion, schema information, and syntax highlighting features.
+## Working on your graph locally
 
-Then, follow the development cycle below:
+After completing the `rover init` flow, run the command you see in your terminal under **Next steps** (it will start with your `APOLLO_KEY`). This allows you to work with Apollo Router locally, giving you a way to design and test your supergraph in a safe environment, without the need to deploy anything yet.
 
-1. [Add your REST API details using @source](https://www.apollographql.com/docs/graphos/schema-design/connectors/directives#source). 
-2. Define the types and fields you want your GraphQL API to expose. Use the inline comments labeled with a ✏️ to follow along.
-3. [Configure the Connector's request details](https://www.apollographql.com/docs/graphos/schema-design/connectors/requests).
-4. [Configure the Connector's response mapping](https://www.apollographql.com/docs/graphos/schema-design/connectors/responses). You can use the [Connectors Mapping Playground](https://www.apollographql.com/connectors-mapping-playground) to help convert JSON responses to and from GraphQL types.
-5. Run operations and debug your API following the instructions in the section below.
+You’ll get automatic [build checks](https://www.apollographql.com/docs/graphos/platform/schema-management/checks#build-checks-1), so you can identify issues early and make sure your services work together. It’s a fast way to iterate with confidence before going live.
 
-📓 **Note:** If you’re working with APIs that require headers, you’ll need to include them in `products.graphql` and add a router configuration file (`router.yaml`) to your project directory.
+Once you run the command, the CLI will start watching your files for updates. Every time you make a change, Rover checks to see if the schema is valid. You can think of it as “hot-reloading” for your GraphQL schema. [More details about the dev command](https://www.apollographql.com/docs/rover/commands/dev).
 
-To learn more about headers and other advanced features like configuring environment variables, telemetry, and authentication, visit [Apollo’s docs on working with Router](https://community.apollographql.com/c/graph-os/getting-started/35).
+## The design process
 
-ℹ️ **Tip:** If you run into any issues or difficulties, please reach out via the [Apollo Community](https://community.apollographql.com/c/graph-os/getting-started/35). Click **New Topic** to start a discussion–the Apollo team is here to help!
+The best way to get started with schema design is to check out the different [schema types](https://www.apollographql.com/docs/graphos/schema-design) that make up your graph. You can also skip and go straight to Apollo’s Schema Design Guides and Principles, starting with [Demand-Oriented Schema Design](https://www.apollographql.com/docs/graphos/schema-design/guides/demand-oriented-schema-design).
 
-# Debugging your schema
-
-The Apollo dev toolkit includes a few debugging tools to help you design and develop your graph. The journey looks a little something like this:
-
-1. Design your schema with Apollo’s IDE extensions
-2. Check for errors each time you save
-3. Debug Connectors in Sandbox
-4. Rinse and repeat until you're happy with your API!
-
-## Design your schema with Apollo’s IDE extensions
-
-Apollo’s IDE extensions are designed to help you catch and correct any issues related to schema design as early as possible. Lean on their instant feedback and autocomplete capabilities to help you create types, fields, arguments, and Connectors.
-
-## Check for errors each time you save
-
-When you run `rover dev`, Rover starts watching your files for updates. Every time you make a change, Rover checks to see if the schema is valid. You can think of it as “hot-reloading” for your GraphQL schema. [More details about the dev command](https://www.apollographql.com/docs/rover/commands/dev).
-
-## Debug Connectors in Sandbox
+## Debugging Apollo Connectors
 
 ![A screenshot of the Connectors debugger in Apollo Sandbox](connectors_debugger.png)
 
-In Apollo Sandbox, you can access the Connectors Debugger by selecting it from the **Response** drop-down on the right side of your screen. The debugger will provide detailed insights into network calls, including response bodies, errors, and connector-related syntax. You can also visit Apollo's docs to [learn more about troubleshooting Connectors](https://www.apollographql.com/docs/graphos/schema-design/connectors/troubleshooting#return-debug-info-in-graphql-responses).
+In Apollo Sandbox, you can access the Connectors Debugger by selecting it from the Response drop-down on the right side of your screen. The debugger will provide detailed insights into network calls, including response bodies, errors, and connector-related syntax. You can also visit Apollo's docs to [learn more about troubleshooting Connectors](https://www.apollographql.com/docs/graphos/schema-design/connectors/troubleshooting#return-debug-info-in-graphql-responses).
 
 # Publishing changes to GraphOS Studio
 
-When you publish a schema to GraphOS, it becomes part of your schema’s version history and is available for checks, composition, and collaboration. When you run `rover init`, GraphOS takes care of your first publish for you.
+Publishing your graph saves your schema to the GraphOS registry, allowing you to track its evolution and collaborate smoothly with your team when needed. GraphOS handles your first publish for you during `init` and creates an environment (or graph variant) called `current`, but any subsequent changes you make will require additional publishes.
 
-Once you’ve made changes to your schema files and are happy with the state of your API, or if you’d like to test the experience of publishing schema changes to GraphOS Studio, paste and run the following command in your terminal:
+Once you're happy with the state of your graph, replace the placeholder items in this command with your own and run it:
 
 ```
-rover subgraph publish your-graph-id@main \ # Replace this with your `APOLLO_GRAPH_REF` value
+rover subgraph publish your-graph-id@current \ # Replace this with your APOLLO_GRAPH_REF value
   --schema "./products.graphql" \
-  --name products-subgraph \
-  --routing-url "https://my-running-subgraph.com/api" # If you don't have a running API yet, you can replace this with http://localhost:4000
+  --name products \
 ```
 
-📓 **Note:** For production-ready APIs, [integrating Rover into your CI/CD](https://www.apollographql.com/docs/rover/ci-cd) ensures schema validation, reduces the risk of breaking changes, and improves collaboration. 
+**📓 Note:** The `rover subgraph publish` command usually includes a `--routing-url` flag, which is only required during your first publish or any time you want to change your routing URL. Otherwise, this flag can be left out. [Review other command options](https://www.apollographql.com/docs/rover/commands/subgraphs#publishing-a-subgraph-schema-to-graphos).
+
+# Deploying Apollo Router
+
+For your supergraph to work, two things must be true:
+
+**The Apollo Router must be deployed.** The Router is what makes your graph live. It connects to GraphOS to fetch your published schema and serves a single GraphQL endpoint for your clients. It handles the work of calling the right subgraphs and combining their results behind the scenes.
+
+**Each service needs to be reachable by the router.** When working with Apollo Connectors, your services become reachable via the REST API(s) you bring into your schema(s).
+
+If you already know how to deploy and host the router, excellent! If you’d like some guidance for this step, [head over to Studio](https://studio.apollographql.com/) to set your endpoint and review deployment options.
 
 # Security
 
@@ -105,23 +79,19 @@ For a more secure and reliable API, Apollo recommends updating your CORS policy 
 - Specifying which origins, HTTP methods, and headers are allowed to interact with your API
 - Turning off GraphQL introspection to limit the exposure of your API schema
 
-Making these updates helps safeguard your API against common vulnerabilities and unauthorized access. To learn more, [review Apollo’s documentation on Graph Security](https://www.apollographql.com/docs/graphos/platform/security/overview).
+Making these updates helps safeguard your API against common vulnerabilities and unauthorized access. To learn more, check out [Apollo’s documentation on Graph Security](https://www.apollographql.com/docs/graphos/platform/security/overview).
 
 # Additional resources
 
-## Deploying your graph
-
-- [Supergraph routing with GraphOS Router](https://www.apollographql.com/docs/graphos/routing/about-router)
-- [Self-hosted Deployment](https://www.apollographql.com/docs/graphos/routing/self-hosted)
-- [Router configuration](https://www.apollographql.com/docs/graphos/routing/configuration)
-
-## More on graph development
-
+## Graph development
 - [Introduction to Apollo Federation](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/federation)
 - [Schema Design with Apollo GraphOS](https://www.apollographql.com/docs/graphos/schema-design)
 - [IDE support for schema development](https://www.apollographql.com/docs/graphos/schema-design/ide-support)
 
-## More about Connectors
-
-- [Tutorial: GraphQL meets REST with Apollo Connectors](https://www.apollographql.com/tutorials/connectors-intro-rest)
+## Connectors
+- [Apollo Connectors Quickstart](https://www.apollographql.com/docs/graphos/connectors/getting-started)
 - [Connectors Community Repo](https://github.com/apollographql/connectors-community)
+
+## Apollo Router
+- [Self-hosting the Apollo Router](https://www.apollographql.com/docs/graphos/routing/self-hosted)
+- [Router configuration](https://www.apollographql.com/docs/graphos/routing/configuration)

--- a/start-with-rest/products.graphql
+++ b/start-with-rest/products.graphql
@@ -13,13 +13,12 @@ extend schema
     import: ["@connect", "@source"]
   )
 
-# A @source directive defines a shared data source for multiple Connectors.
-# ✏️ Replace the `name` and `baseURL` of this @source with your own REST API.
+# ✏️ This schema is using a demo REST API as its @source. Replace the `name` and `baseURL` of it with your own REST API.
 @source(
   name: "ecomm"
   # A @source directive defines a shared data source for multiple Connectors.
   http: {
-    baseURL: "https://ecommerce.demo-api.apollo.dev/"
+    baseURL: "https://ecommerce.demo-api.apollo.dev/" 
     headers: [
       # If your API requires headers, add them here and in your router.yaml file.
       # Example:

--- a/start-with-typescript/getting-started.md
+++ b/start-with-typescript/getting-started.md
@@ -1,159 +1,57 @@
+# Overview
 
-👋 Hi there! This guide walks you through building a _subgraph_ with Apollo Server, TypeScript, and Apollo Federation.
+👋 Hi there!
 
-- [Setup](#setup)
-  - [Apollo Federation components](#apollo-federation-components)
-  - [Components of a GraphQL subgraph server](#components-of-a-graphql-subgraph-server)
-    - [The schema (`products.graphql`)](#the-schema-productsgraphql)
-    - [Resolvers (`src/resolvers`)](#resolvers-srcresolvers)
-    - [The server (`src/index.ts`)](#the-server-srcindexts)
-- [Make your first request](#make-your-first-request)
-  - [To the subgraph server (http://localhost:4001)](#to-the-subgraph-server-httplocalhost4001)
-  - [To the supergraph (http://localhost:4000)](#to-the-supergraph-httplocalhost4000)
-  - [Choosing a port to work with](#choosing-a-port-to-work-with)
-- [Time to build your API](#time-to-build-your-api)
-- [Debugging your schema](#debugging-your-schema)
-  - [Design your schema with Apollo’s IDE extensions](#design-your-schema-with-apollos-ide-extensions)
-  - [Check for errors each time you save](#check-for-errors-each-time-you-save)
-- [Publishing your changes to GraphOS Studio](#publishing-your-changes-to-graphos-studio)
-- [Security](#security)
-- [Additional resources](#additional-resources)
-  - [More on GraphQL server development](#more-on-graphql-server-development)
-  - [More on federation](#more-on-federation)
-  - [Deploying your supergraph](#deploying-your-supergraph)
+Your new graph is set up with [Apollo Federation](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/federation). This means it’s built to grow, even if you’re starting with just one service. Right now, that service is defined in `products.graphql`, and you can treat it like a regular GraphQL API as you build it out.
 
-# Setup
+Your service uses [Apollo Server](https://www.apollographql.com/docs/apollo-server) as its backend, a production-ready GraphQL server that connects your schema to any data source and handles all GraphQL execution, caching, and performance optimizations.
 
-## Apollo Federation components
+This project is also set up to use [Apollo Router](https://www.apollographql.com/docs/graphos/routing) as the entry point for all requests to your graph. It’s a great way to get features like tracing, metrics, and caching out of the box. It gives you a single place to configure settings for your graph, like traffic shaping, authorization, and more. For now, the router simply forwards requests to your service, but as your graph grows, it can pull data from multiple places and return one clear, consistent result.
 
-This project gets you started with building a federated architecture called a _supergraph_. This architecture lets different teams independently develop and deploy parts of the supergraph while maintaining a unified experience for clients.
+# Designing your graph
 
-A supergraph contains a _router_, and one or more _subgraphs_.
+## IDE extensions for graph development
 
-The router is the single access point for the supergraph. It receives incoming operations from clients and intelligently routes them across subgraphs before returning a unified response.
+[Apollo’s IDE extensions](https://www.apollographql.com/docs/ide-support) are designed to help you catch and correct any issues related to schema design as early as possible. Lean on their instant feedback and autocomplete capabilities to help you create the types, fields, arguments, and more.
 
-A subgraph is an individual GraphQL server that takes responsibility for a specific domain in the supergraph.
+## Working on your graph locally
 
-## Components of a GraphQL subgraph server
+After completing the `rover init` flow, run the command you see in your terminal under **Next steps** (it will start with your `APOLLO_KEY`). This allows you to work with Apollo Router locally, giving you a way to design and test your supergraph in a safe environment, without the need to deploy anything yet.
 
-Before diving in, it's helpful to understand the structure and purpose of the files included in this template. This overview will help you navigate the codebase more effectively.
+You’ll get automatic [build checks](https://www.apollographql.com/docs/graphos/platform/schema-management/checks#build-checks-1), so you can identify issues early and make sure your services work together. It’s a fast way to iterate with confidence before going live.
 
-### The schema (`products.graphql`)
+Once you run the command, the CLI will start watching your files for updates. Every time you make a change, Rover checks to see if the schema is valid. You can think of it as “hot-reloading” for your GraphQL schema. [More details about the dev command](https://www.apollographql.com/docs/rover/commands/dev).
 
-The schema describes what data is available, how it’s structured, and how it can be requested or modified. It’s written using GraphQL’s Schema Definition Language (SDL), which lets you define the shape and capabilities of an API in a clear, type-safe way that is also backend-agnostic.
+## The design process
 
-### Resolvers (`src/resolvers`)
+The best way to get started with schema design is to check out the different [schema types](https://www.apollographql.com/docs/graphos/schema-design) that make up your graph. You can also go straight to Apollo’s schema design guides, starting with [Demand-Oriented Schema Design](https://www.apollographql.com/docs/graphos/schema-design/guides/demand-oriented-schema-design).
 
-A resolver function populates the data for a particular field in the schema. Resolvers are defined in a resolvers map that follows the hierarchy of the schema.
+# Publishing changes to GraphOS Studio
 
-You can find the resolvers for this project in `src/resolvers`. Each file corresponds to a type in your schema.
+Publishing your graph saves your schema to the GraphOS registry, allowing you to track its evolution and collaborate smoothly with your team when needed. GraphOS handles your first publish for you during `init` and creates an environment (or graph variant) called `current`, but any subsequent changes you make will require additional publishes.
 
-### The server (`src/index.ts`)
-
-The server is in charge of making sure requests are valid, finding the right data, and sending it back to the requester.
-
-**📓 Note:** This graph is using [Apollo Server](https://github.com/apollographql/apollo-server)—an open source server library that is quick and easy to set up, giving you a way to build a production-ready, self-documenting GraphQL API.
-
-
-# Make your first request
-
-## To the subgraph server (http://localhost:4001)
-
-1. Open `products.graphql` and take a look at your starter schema.
-2. In the terminal, run `npm ci`, then `npm run dev` to start the subgraph server.
-3. In the browser, go to http://localhost:4001, where the subgraph server is running. You'll have access to Apollo Sandbox—a local, in-browser GraphQL playground, where you can run GraphQL operations and test your API as you design it.
-4. In Sandbox, paste the following GraphQL query in the **Operation** section:
+Once you're happy with the state of your graph, replace the placeholder items in this command with your own and run it:
 
 ```
-query GetProducts {
-  products {
-    id
-    name
-    description
-  }
-}
-```
-
-5. Click `► GetProducts` to run the request. You'll get a response back with data for the product's id, name, and description; exactly the properties you asked for in the query! 🎉
-
-## To the supergraph (http://localhost:4000)
-
-1. In a _new_ terminal window, run the `rover dev` command provided in the output of `rover init` under **Next steps**. The `dev` command starts a local development session with the router.
-2. In the browser, go to http://localhost:4000, where `rover dev` is running. You'll have access to another Sandbox. Make sure you still have the subgraph server running from the previous section.
-3. In Sandbox, paste the same GraphQL query in the **Operation** section:
-
-```
-query GetProducts {
-  products {
-    id
-    name
-    description
-  }
-}
-```
-
-4. Click `► GetProducts` to run the request. You'll get the same response back as before, but this time, the request was handled by the router.
-
-## Choosing a port to work with
-
-As you start building your schema, you can use Apollo Sandbox to send requests to your subgraph or supergraph.
-
-When you want to test your subgraph server in isolation, use the Sandbox running at http://localhost:4001, started by the `npm run dev` command. This is recommended when you're just starting out, or when you want to focus on a specific subgraph server.
-
-When you want to test the supergraph as a whole, use the Sandbox running at http://localhost:4000, started by the `rover dev` command. This is recommended when you have more than one subgraph in your supergraph.
-
-📓 **Note:** If you are using `rover dev` and `localhost:4000`, you'll need to start the subgraph server _first_ by running `npm ci` and `npm run dev`—otherwise, you'll encounter errors when running requests in Sandbox.
-
-# Time to build your API
-
-You’re all set to start building.
-
-
-First, make sure you’ve installed and configured your [IDE extension of choice](https://www.apollographql.com/docs/graphos/schema-design/ide-support) so you can rely on its autocompletion, schema information, and syntax highlighting features.
-
-Then, follow the development cycle below:
-
-1. Define the types and fields in the schema.
-2. Write the resolver function(s) that provide the data for those types and fields.
-3. Run operations and debug your API following the instructions in the section below.
-
-📓 **Note:** The [GraphQL Code Generator](https://the-guild.dev/graphql/codegen) has been automatically set up and configured for you. It reads your GraphQL schema and generates TypeScript types to use across your server. This helps you keep your TypeScript types up to date as you make changes to your schema, allowing you to focus on development instead of manually updating type definitions.
-
-Whenever you modify your schema, run `npm run codegen` to ensure your generated types are up to date as well.
-
-ℹ️ **Tip:** If you run into any issues or difficulties, please reach out via the [Apollo Community](https://community.apollographql.com/c/graph-os/getting-started/35). Click **New Topic** to start a discussion–the Apollo team is here to help!
-
-# Debugging your schema
-
-The Apollo dev toolkit includes a few debugging tools to help you design and develop your graph. The journey looks a little something like this:
-
-1. Design your schema with Apollo’s IDE extensions
-2. Check for errors each time you save
-3. Rinse and repeat until you're happy with your API!
-
-## Design your schema with Apollo’s IDE extensions
-
-Apollo’s IDE extensions are designed to help you catch and correct any issues related to schema design as early as possible. Lean on their instant feedback and autocomplete capabilities to help you create types, fields, and arguments.
-
-## Check for errors each time you save
-
-With `rover dev`, Rover starts watching your files for updates. Every time you make a change, Rover checks to see if the schema is valid. You can think of it as “hot-reloading” for your GraphQL schema. [More details about the dev command](https://www.apollographql.com/docs/rover/commands/dev).
-
-
-# Publishing your changes to GraphOS Studio
-
-When you publish a schema to GraphOS, it becomes part of your schema’s version history and is available for checks, composition, and collaboration. When you run `rover init`, GraphOS takes care of your first publish for you.
-
-Once you’ve made changes to your schema files and are happy with the state of your API, or if you’d like to test the experience of publishing schema changes to GraphOS Studio, paste and run the following command in your terminal:
-
-```
-rover subgraph publish your-graph-id@main \ # Replace this with your `APOLLO_GRAPH_REF` value
+rover subgraph publish your-graph-id@current \ # Replace this with your APOLLO_GRAPH_REF value
   --schema "./products.graphql" \
-  --name products-subgraph \
-  --routing-url "https://my-running-subgraph.com/api" # If you don't have a running API yet,replace this with http://localhost:4000
+  --name products \
+  --routing-url "https://my-running-subgraph.com/api" # Replace this with your service URL
 ```
 
-📓 **Note:** For production-ready APIs, [integrating Rover into your CI/CD](https://www.apollographql.com/docs/rover/ci-cd) ensures schema validation, reduces the risk of breaking changes, and improves collaboration.
+**📓 Note:** The `rover subgraph publish` command usually includes a `--routing-url` flag, which is only required during your first publish or any time you want to change your routing URL. Otherwise, this flag can be left out. [Review other command options](https://www.apollographql.com/docs/rover/commands/subgraphs#publishing-a-subgraph-schema-to-graphos).
+
+# Deployment
+
+For your supergraph to work, two things must be true:
+
+**The Apollo Router must be deployed.** The Router is what makes your graph live. It connects to GraphOS to fetch your published schema and serves a single GraphQL endpoint for your clients. It handles the work of calling the right subgraphs and combining their results behind the scenes.
+
+**Each service needs to be reachable by the router.** Your service’s backend (in this case, Apollo Server) also needs to be deployed to expose a URL that the router can call.
+
+If you already know how to deploy and host the router, excellent! If you’d like some guidance for this step, [head over to Studio](https://studio.apollographql.com/) to set your endpoint and review deployment options.
+
+For instructions on how to deploy Apollo Server (using AWS Lambda or Heroku), [visit the Apollo Server docs](https://www.apollographql.com/docs/apollo-server/deployment/lambda).
 
 # Security
 
@@ -162,24 +60,18 @@ For a more secure and reliable API, Apollo recommends updating your CORS policy 
 - Specifying which origins, HTTP methods, and headers are allowed to interact with your API
 - Turning off GraphQL introspection to limit the exposure of your API schema
 
-Making these updates helps safeguard your API against common vulnerabilities and unauthorized access. To learn more, [review Apollo’s documentation on Graph Security](https://www.apollographql.com/docs/graphos/platform/security/overview).
+Making these updates helps safeguard your API against common vulnerabilities and unauthorized access. To learn more, check out [Apollo’s documentation on Graph Security](https://www.apollographql.com/docs/graphos/platform/security/overview).
 
 # Additional resources
 
-## More on GraphQL server development
-
-- [GraphQL basics](https://graphql.com/learn/what-is-graphql/)
-- [How does a GraphQL server work?](https://graphql.com/learn/how-does-graphql-work/)
-- [Introduction to Apollo Server](https://www.apollographql.com/docs/apollo-server)
-
-## More on federation
-
+## Graph development
 - [Introduction to Apollo Federation](https://www.apollographql.com/docs/graphos/schema-design/federated-schemas/federation)
-- [Tutorial: Federation with TypeScript & Apollo Server](https://www.apollographql.com/tutorials/intro-typescript)
-- [More educational materials covering TypeScript and Federation](https://www.apollographql.com/tutorials/browse/?categories=federation&languages=TypeScript)
+- [Schema Design with Apollo GraphOS](https://www.apollographql.com/docs/graphos/schema-design)
+- [IDE support for schema development](https://www.apollographql.com/docs/graphos/schema-design/ide-support)
 
-## Deploying your supergraph
+## Apollo Server
+- [Apollo Server Docs](https://www.apollographql.com/docs/apollo-server)
 
-- [Supergraph routing with GraphOS Router](https://www.apollographql.com/docs/graphos/routing/about-router)
-- [Self-hosted Deployment](https://www.apollographql.com/docs/graphos/routing/self-hosted)
+## Apollo Router
+- [Self-hosting the Apollo Router](https://www.apollographql.com/docs/graphos/routing/self-hosted)
 - [Router configuration](https://www.apollographql.com/docs/graphos/routing/configuration)

--- a/start-with-typescript/getting-started.md
+++ b/start-with-typescript/getting-started.md
@@ -1,3 +1,22 @@
+
+- [Overview](#overview)
+  - [Components of your GraphQL service](#components-of-your-graphql-service)
+    - [The schema (`products.graphql`)](#the-schema-productsgraphql)
+    - [Resolvers (`src/resolvers`)](#resolvers-srcresolvers)
+    - [The server (`src/index.ts`)](#the-server-srcindexts)
+- [Designing your graph](#designing-your-graph)
+  - [IDE extensions for graph development](#ide-extensions-for-graph-development)
+  - [Working on your graph locally](#working-on-your-graph-locally)
+  - [The design process](#the-design-process)
+- [Publishing changes to GraphOS Studio](#publishing-changes-to-graphos-studio)
+- [Deployment](#deployment)
+- [Security](#security)
+- [Additional resources](#additional-resources)
+  - [Graph development](#graph-development)
+  - [Apollo Server](#apollo-server)
+  - [Apollo Router](#apollo-router)
+
+
 # Overview
 
 👋 Hi there!
@@ -7,6 +26,25 @@ Your new graph is set up with [Apollo Federation](https://www.apollographql.com/
 Your service uses [Apollo Server](https://www.apollographql.com/docs/apollo-server) as its backend, a production-ready GraphQL server that connects your schema to any data source and handles all GraphQL execution, caching, and performance optimizations.
 
 This project is also set up to use [Apollo Router](https://www.apollographql.com/docs/graphos/routing) as the entry point for all requests to your graph. It’s a great way to get features like tracing, metrics, and caching out of the box. It gives you a single place to configure settings for your graph, like traffic shaping, authorization, and more. For now, the router simply forwards requests to your service, but as your graph grows, it can pull data from multiple places and return one clear, consistent result.
+
+## Components of your GraphQL service
+
+Before diving in, it's helpful to understand the structure and purpose of some of the files included in this template. This will help you navigate the codebase more effectively.
+
+### The schema (`products.graphql`)
+
+The schema describes what data is available, how it’s structured, and how it can be requested or modified. It’s written using GraphQL’s Schema Definition Language (SDL), which lets you define the shape and capabilities of an API in a clear, type-safe way that is also backend-agnostic.
+
+### Resolvers (`src/resolvers`)
+
+A resolver function populates the data for a particular field in the schema. Resolvers are defined in a resolvers map that follows the hierarchy of the schema.
+
+You can find the resolvers for this project in `src/resolvers`. Each file corresponds to a type in your schema.
+
+### The server (`src/index.ts`)
+
+The server is in charge of making sure requests are valid, finding the right data, and sending it back to the requester.
+
 
 # Designing your graph
 


### PR DESCRIPTION
# What changed?

This PR introduces some updates to our current `getting-started.md` files, for both the Connectors workflow and the Apollo Server/TypeScript workflow.

**This update is two-fold:**
- On one hand, we're introducing some improvements based on what we've learned since releasing `init` (primarily, the need to be clearer and more concise.)
- On the other hand, we're also preparing for the release of the `deploy` project (i.e., adding a `Set endpoint` path in Studio to give users guidance re: deploying Apollo Router when it's a necessary step for successful onboarding), and want to add a handshake between what the user sees in their IDE post-`init`, and what will be awaiting for them in Studio once they're ready to move past the schema design step.

# What _isn't_ changing
We've previously talked about simplifying the schemas that we generate via `init` and turning them into something closer to a `Hello world` experience. I've decided to descope that from this update after discussing it with the Dev Ed team, as it would require updating both Odyssey and our Quick Start docs—adding an extra layer to Growth's and Dev Ed's current bandwidth/capacity.

# How to review this PR
- Take a look at the changed files
- Give each `getting-started.md` doc a thorough, critical read (including checking out the links that are sprinkled throughout)