### PR TITLE
Update Apollo Federation link to v2.11

### DIFF
--- a/start-with-rest/products.graphql
+++ b/start-with-rest/products.graphql
@@ -6,7 +6,7 @@
 
 extend schema
   @link( # Enable this schema to use Apollo Federation features
-    url: "https://specs.apollo.dev/federation/v2.10"
+    url: "https://specs.apollo.dev/federation/v2.11"
   )
   @link( # Enable this schema to use Apollo Connectors
     url: "https://specs.apollo.dev/connect/v0.2"


### PR DESCRIPTION
This shouldn't have any practical affect, but makes it consistent with what's in `supergraph.yaml`