### PR TITLE
feat(add-mcp): Add JSON schema validation for VSCode in MCP template

### DIFF
--- a/add-mcp/.vscode/schemas/README.md
+++ b/add-mcp/.vscode/schemas/README.md
@@ -1,0 +1,70 @@
+# Apollo Configuration Schemas for VS Code
+
+This directory contains JSON schemas that provide IntelliSense, validation, and auto-completion for Apollo configuration files in VS Code.
+
+## MCP Server Schema
+
+**File:** `mcp-server.schema.json`
+
+Provides validation and IntelliSense for Apollo MCP Server configuration files:
+- `.apollo/mcp.*.yaml`
+- `mcp.*.yaml`
+
+This schema covers all known MCP server configuration options including:
+- Transport configuration (stdio, streamable_http, websocket)
+- GraphQL introspection settings
+- Operation sources (collection, manifest, introspection)
+- Authentication and CORS settings
+- Logging configuration
+
+## Router Configuration Schema
+
+**File:** `router-config.schema.json`
+
+Provides basic validation for Apollo Router configuration files:
+- `router.yaml`
+- `.apollo/router*.yaml`
+
+### Generating Complete Router Schema
+
+For the most complete and up-to-date Apollo Router configuration schema, generate it locally:
+
+```bash
+# Make sure you have Apollo Router installed
+# Download from: https://github.com/apollographql/router/releases
+
+# Generate the complete schema
+./router config schema > .vscode/schemas/router-config.schema.json
+```
+
+This will replace the basic schema with the complete, official schema that includes all router configuration options.
+
+## VS Code Configuration
+
+The schemas are automatically configured in `.vscode/settings.json`:
+
+```json
+{
+  "yaml.schemas": {
+    ".vscode/schemas/mcp-server.schema.json": [
+      ".apollo/mcp.*.yaml",
+      "mcp.*.yaml"
+    ],
+    ".vscode/schemas/router-config.schema.json": [
+      "router.yaml",
+      "*/router.yaml",
+      ".apollo/router*.yaml"
+    ]
+  }
+}
+```
+
+## Usage
+
+Once configured, VS Code will automatically provide:
+- ✅ Auto-completion for configuration properties
+- ✅ Validation errors for invalid configurations
+- ✅ Documentation on hover for configuration options
+- ✅ Schema-aware formatting and linting
+
+Perfect for live demos and development! 🎬

--- a/add-mcp/.vscode/schemas/mcp-server.schema.json
+++ b/add-mcp/.vscode/schemas/mcp-server.schema.json
@@ -1,0 +1,168 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Apollo MCP Server Configuration",
+  "description": "JSON schema for Apollo MCP Server YAML configuration files",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Human-readable name for this MCP server instance"
+    },
+    "description": {
+      "type": "string",
+      "description": "Description of what this MCP server provides"
+    },
+    "endpoint": {
+      "type": "string",
+      "format": "uri",
+      "description": "GraphQL API endpoint URL (e.g., http://localhost:4000)"
+    },
+    "overrides": {
+      "type": "object",
+      "description": "Configuration overrides for MCP server behavior",
+      "properties": {
+        "mutation_mode": {
+          "type": "string",
+          "enum": ["all", "none", "safe"],
+          "description": "Controls which GraphQL mutations are exposed as MCP tools. 'all' exposes all mutations, 'none' disables mutations, 'safe' only exposes approved mutations"
+        }
+      },
+      "additionalProperties": false
+    },
+    "operations": {
+      "type": "object",
+      "description": "Configuration for GraphQL operations source",
+      "properties": {
+        "source": {
+          "type": "string",
+          "enum": ["collection", "manifest", "introspection"],
+          "description": "Source of GraphQL operations: 'collection' uses Apollo Studio collections, 'manifest' uses a manifest file, 'introspection' discovers operations via schema introspection"
+        },
+        "id": {
+          "type": "string",
+          "description": "Identifier for the operation collection (when source is 'collection')"
+        }
+      },
+      "additionalProperties": false
+    },
+    "introspection": {
+      "type": "object",
+      "description": "GraphQL introspection capabilities configuration",
+      "properties": {
+        "introspect": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable schema introspection for AI to understand your GraphQL schema"
+            }
+          }
+        },
+        "search": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable search capabilities across the GraphQL schema"
+            }
+          }
+        },
+        "execute": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable query/mutation execution capabilities"
+            }
+          }
+        },
+        "validate": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Enable GraphQL query validation"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "transport": {
+      "type": "object",
+      "description": "MCP transport configuration",
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": ["stdio", "streamable_http", "websocket"],
+          "description": "Transport protocol for MCP communication. 'stdio' for process communication, 'streamable_http' for HTTP streaming, 'websocket' for WebSocket connections"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535,
+          "description": "Port number for HTTP/WebSocket transport (not used for stdio)"
+        }
+      },
+      "additionalProperties": false
+    },
+    "cors": {
+      "type": "object",
+      "description": "CORS configuration for HTTP transport",
+      "properties": {
+        "origin": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ],
+          "description": "Allowed origins for CORS requests"
+        },
+        "credentials": {
+          "type": "boolean",
+          "description": "Allow credentials in CORS requests"
+        }
+      },
+      "additionalProperties": false
+    },
+    "authentication": {
+      "type": "object",
+      "description": "Authentication configuration",
+      "properties": {
+        "bearer_token": {
+          "type": "string",
+          "description": "Bearer token for GraphQL API authentication"
+        },
+        "api_key": {
+          "type": "string",
+          "description": "API key for GraphQL API authentication"
+        }
+      },
+      "additionalProperties": false
+    },
+    "logging": {
+      "type": "object",
+      "description": "Logging configuration",
+      "properties": {
+        "level": {
+          "type": "string",
+          "enum": ["error", "warn", "info", "debug", "trace"],
+          "description": "Log level for the MCP server"
+        },
+        "format": {
+          "type": "string",
+          "enum": ["json", "text"],
+          "description": "Log output format"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/add-mcp/.vscode/schemas/router-config.schema.json
+++ b/add-mcp/.vscode/schemas/router-config.schema.json
@@ -1,0 +1,113 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Apollo Router Configuration",
+  "description": "JSON schema for Apollo Router YAML configuration files. For the complete, up-to-date schema, generate it locally with: ./router config schema > router-config.schema.json",
+  "type": "object",
+  "properties": {
+    "supergraph": {
+      "type": "object",
+      "description": "Supergraph configuration",
+      "properties": {
+        "introspection": {
+          "type": "boolean",
+          "description": "Enable GraphQL introspection on the supergraph"
+        },
+        "defer_support": {
+          "type": "boolean",
+          "description": "Enable @defer directive support"
+        }
+      }
+    },
+    "federation_version": {
+      "type": "string",
+      "description": "Apollo Federation version to use"
+    },
+    "cors": {
+      "type": "object",
+      "description": "CORS configuration",
+      "properties": {
+        "origins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Allowed origins for CORS requests"
+        },
+        "allow_credentials": {
+          "type": "boolean",
+          "description": "Allow credentials in CORS requests"
+        }
+      }
+    },
+    "headers": {
+      "type": "object",
+      "description": "Header forwarding and manipulation configuration",
+      "properties": {
+        "all": {
+          "type": "object",
+          "description": "Configuration applied to all requests"
+        },
+        "subgraphs": {
+          "type": "object",
+          "description": "Per-subgraph header configuration"
+        }
+      }
+    },
+    "plugins": {
+      "type": "object",
+      "description": "Router plugin configuration"
+    },
+    "rhai": {
+      "type": "object",
+      "description": "Rhai scripting configuration",
+      "properties": {
+        "scripts": {
+          "type": "string",
+          "description": "Path to Rhai scripts directory"
+        }
+      }
+    },
+    "authentication": {
+      "type": "object",
+      "description": "Authentication and authorization configuration"
+    },
+    "authorization": {
+      "type": "object",
+      "description": "Authorization directives configuration"
+    },
+    "limits": {
+      "type": "object",
+      "description": "Query complexity and rate limiting configuration",
+      "properties": {
+        "max_depth": {
+          "type": "integer",
+          "description": "Maximum query depth allowed"
+        },
+        "max_height": {
+          "type": "integer",
+          "description": "Maximum query height allowed"
+        },
+        "max_aliases": {
+          "type": "integer",
+          "description": "Maximum number of aliases allowed in a query"
+        }
+      }
+    },
+    "include_subgraph_errors": {
+      "type": "object",
+      "description": "Configuration for including subgraph errors in responses",
+      "properties": {
+        "all": {
+          "type": "boolean",
+          "description": "Include all subgraph errors"
+        },
+        "subgraphs": {
+          "type": "object",
+          "description": "Per-subgraph error inclusion settings"
+        }
+      }
+    }
+  },
+  "additionalProperties": true,
+  "x-generated-note": "This is a basic schema. For the complete Apollo Router configuration schema, run: ./router config schema > router-config.schema.json"
+}

--- a/add-mcp/.vscode/settings.json
+++ b/add-mcp/.vscode/settings.json
@@ -151,7 +151,7 @@
   // ==========================================================================
   // YAML CONFIGURATION FOR APOLLO CONFIG FILES
   // ==========================================================================
-  
+
   // Configure YAML settings for Apollo configuration files
   "[yaml]": {
     "editor.tabSize": 2,
@@ -162,6 +162,29 @@
       "comments": false,
       "strings": true
     }
+  },
+
+  // ==========================================================================
+  // JSON SCHEMA CONFIGURATION FOR APOLLO ROUTER AND MCP SERVER
+  // ==========================================================================
+
+  // YAML Schema validation for Apollo configuration files
+  // This provides intellisense, validation, and auto-completion for Apollo config files
+  // For detailed instructions, see: .vscode/schemas/README.md
+  "yaml.schemas": {
+    // Apollo MCP Server configuration schema
+    ".vscode/schemas/mcp-server.schema.json": [
+      ".apollo/mcp.*.yaml",
+      "mcp.*.yaml"
+    ],
+
+    // Apollo Router configuration schema (basic version)
+    // For complete schema, run: ./router config schema > .vscode/schemas/router-config.schema.json
+    ".vscode/schemas/router-config.schema.json": [
+      "router.yaml",
+      "*/router.yaml",
+      ".apollo/router*.yaml"
+    ]
   },
 
 


### PR DESCRIPTION
## Summary

Adds JSON schema files and VSCode configuration to provide IntelliSense and validation for MCP server configuration and
  router config files in the `add-mcp` template.