### PR TITLE
Update to Connect v0.3 and federation 2.12

### DIFF
--- a/start-with-rest/router.yaml
+++ b/start-with-rest/router.yaml
@@ -1,5 +1,4 @@
-connectors:
-  preview_connect_v0_3: true
+# connectors:
   # sources:
   #   subgraph.source_name:
   #     $config:

--- a/start-with-rest/schema.graphql
+++ b/start-with-rest/schema.graphql
@@ -6,10 +6,10 @@
 
 extend schema
   @link( # Enable this schema to use Apollo Federation features
-    url: "https://specs.apollo.dev/federation/v2.11"
+    url: "https://specs.apollo.dev/federation/v2.13"
   )
   @link( # Enable this schema to use Apollo Connectors
-    url: "https://specs.apollo.dev/connect/v0.2"
+    url: "https://specs.apollo.dev/connect/v0.3"
     import: ["@connect", "@source"]
   )
 

--- a/start-with-rest/schema.graphql
+++ b/start-with-rest/schema.graphql
@@ -6,7 +6,7 @@
 
 extend schema
   @link( # Enable this schema to use Apollo Federation features
-    url: "https://specs.apollo.dev/federation/v2.13"
+    url: "https://specs.apollo.dev/federation/v2.12"
   )
   @link( # Enable this schema to use Apollo Connectors
     url: "https://specs.apollo.dev/connect/v0.3"


### PR DESCRIPTION
## Summary

- Updates Apollo Connect to v0.3
- Updates federation to 2.13 and then corrects to 2.12

## Changes

Cherry-picked from `mm/connectv3` onto `release/v3`:

- `f2ae7ab` — update to connect v0.3 and fed2.13
- `fe877e1` — switch to fed 2.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)